### PR TITLE
Type promotion and performance updates

### DIFF
--- a/Eleveld_PKsim.jl
+++ b/Eleveld_PKsim.jl
@@ -33,7 +33,7 @@ y = zeros(Float32, length(youts)) # create empty output vector
 PKsim!(y, θ, infusionrate, bolusdose, h, youts)
 
 # Benchmark one patient
-@btime PKsim!($y, $θ, $infusionrate, $bolusdose, $h, $youts) # 2.6 us, 0 allocations
+@btime PKsim!($y, $θ, $infusionrate, $bolusdose, $h, $(Set(youts))) # 2.6 us, 0 allocations
 
 
 ## Simulate all patients
@@ -65,7 +65,8 @@ for studynbr = 1:nstudy
             continue
         end
         θ, infusionrate, bolusdose, time, h, youts = getpatientdata(id, study_df) # get patient data
-        bm = @benchmark PKsim!($y, $θ, $infusionrate, $bolusdose, $h, $youts) # add samples = 100 (or similar?)
+        yset = Set(youts) 
+        bm = @benchmark PKsim!($y, $θ, $infusionrate, $bolusdose, $h, $yset) # add samples = 100 (or similar?)
         benchtime += median(bm.times) # median simulation time
     end
 end

--- a/Eleveld_PKsim.jl
+++ b/Eleveld_PKsim.jl
@@ -8,6 +8,7 @@
 # TODO: run full benchmark with julia 1.8
 
 using Pkg
+cd(@__DIR__)
 Pkg.activate(".")
 
 using CSV, DataFrames, StaticArrays

--- a/Eleveld_PKsim.jl
+++ b/Eleveld_PKsim.jl
@@ -57,6 +57,7 @@ end
 nstudy = 30 # nbr of studies
 benchtime = 0.0 # ns
 for studynbr = 1:nstudy
+    global benchtime
     @show studynbr
     study_df, firstid, lastid = getstudydata(studynbr) # get dataframe for this study
     for id = firstid:lastid

--- a/PKmodels.jl
+++ b/PKmodels.jl
@@ -14,7 +14,7 @@ function update(θ)
 end
 
 # Compute eigenvalues λ for 3 compartment mammillary model
-@inline @fastmath function getλ(θ)
+@inline @fastmath function getλ(θ::AbstractVector{T}) where T
     k10, k12, k13, k21, k31, _ = θ
     b1 = k10 + k12 + k13 + k21 + k31
     b2 = k21 * (k10 + k13 + k31) + k31 * (k10 + k12)
@@ -27,10 +27,10 @@ end
     a4 = b2 / 3
     a5 = a4 - a2
     a6 = (b1 * a4 - b3) / 2
-    a7 = 2(a6 + sqrt(complex(a5^3 + (a3 - a6)^2)) - a3)^(1 / 3.0f0)
+    a7 = 2(a6 + sqrt(complex(a5^3 + (a3 - a6)^2)) - a3)^(1 / T(3))
     a8 = -real(a7)
     a9 = imag(a7)
-    a10 = a9 * sqrt(3) / 2
+    a10 = a9 * sqrt(T(3)) / 2
     a11 = a1 - a8 / 2
 
     return @SVector [-a1 - a8, -a10 - a11, a10 - a11] # The eigenvalues of the continuous-time system matrix

--- a/PKsimulation.jl
+++ b/PKsimulation.jl
@@ -50,13 +50,13 @@ function PKsim!(y, θ, u, v, hs, youts)
     λ, R = update(θ) # Setting up simulator
     j = 1 # counter to keep track of next free spot in y
     x = @SVector zeros(eltype(u), 3) # initial state
-    for i in eachindex(u)
+    for i in eachindex(u, hs, v)
         if i in youts # if we want to compute output
-            x, yi = updatestateoutput(x, hs[i], θ[6], λ, R, u[i], v[i]) # update state and compute output
+            x, yi = @inbounds updatestateoutput(x, hs[i], θ[6], λ, R, u[i], v[i]) # update state and compute output
             y[j] = yi
             j += 1
         else
-            x = updatestate(x, hs[i], λ, u[i], v[i]) # update state
+            x = @inbounds updatestate(x, hs[i], λ, u[i], v[i]) # update state
         end
     end
     return y

--- a/PKsimulation.jl
+++ b/PKsimulation.jl
@@ -29,7 +29,7 @@ end
 end
 
 # Initiate/update state
-@inline @fastmath function updatestate(x, h, λ, u=0.0, v=0.0)
+@inline function updatestate(x::AbstractVector{T}, h, λ, u=zero(T), v=zero(T)) where T
     Φdiag = getΦdiag(λ, h) # compute Φ
     x = bolus(x, v) # update state for bolus
     x = step(x, λ, Φdiag, u) # infusion affect next sample
@@ -37,7 +37,7 @@ end
 end
 
 # Update state and compute output
-@inline @fastmath function updatestateoutput(x, h, V1, λ, R, u=0.0, v=0.0)
+@inline function updatestateoutput(x::AbstractVector{T}, h, V1, λ, R, u=zero(T), v=zero(T)) where T
     Φdiag = getΦdiag(λ, h) # compute Φ
     x = bolus(x, v) # update state for bolus
     y = gety(x, V1, R) # compute output
@@ -49,7 +49,7 @@ end
 function PKsim!(y, θ, u, v, hs, youts)
     λ, R = update(θ) # Setting up simulator
     j = 1 # counter to keep track of next free spot in y
-    x = @SVector [0.0f0, 0.0f0, 0.0f0] # initial state
+    x = @SVector zeros(eltype(u), 3) # initial state
     for i in eachindex(u)
         if i in youts # if we want to compute output
             x, yi = updatestateoutput(x, hs[i], θ[6], λ, R, u[i], v[i]) # update state and compute output


### PR DESCRIPTION
This PR
- prevents accidental promotion of Float32 to Float64 in `getλ`
- makes `youts` a set to make lookup O(1) instead of O(n)
- removes numeric literals in favor of generic `zero` types
- add `@inbounds` to known inbound accesses

On my machine, the last simulation now takes 1.45ms